### PR TITLE
Update android_lib_build.sh

### DIFF
--- a/android_lib_build.sh
+++ b/android_lib_build.sh
@@ -14,14 +14,14 @@ fi
 
 # copy .so files to jniLibs folder
 cd ../
-ARM64="android/app/libs/arm64-v8a"
-ARMv7a="android/app/libs/armeabi-v7a"
+ARM64="Android/app/libs/arm64-v8a"
+ARMv7a="Android/app/libs/armeabi-v7a"
 
 if [ ! -d "$ARM64" ]; then
-    mkdir "$ARM64"
+    mkdir -p "$ARM64"
 fi
 if [ ! -d "$ARMv7a" ]; then
-    mkdir "$ARMv7a"
+    mkdir -p "$ARMv7a"
 fi
 
 cp target/aarch64-linux-android/${LIB_FOLDER}/libwgpu_in_app.so "${ARM64}/libwgpu_in_app.so"


### PR DESCRIPTION
Two small fixes:

- The `Android` directory in the repo starts with a capital-A. This changes the path definition for `ARM64` and `ARMv7a` to match, so they will succeed on case-sensitive filesystems
- My script was failing because I didn't have an `Android/app/libs` directory. This Adds the `-p` flag to `mkdir`, so that intermediate directories are created automatically if they don't exist