### PR TITLE
Starting with the 2024 Edition, it is now required to mark these attributes as unsafe. 

### DIFF
--- a/wgpu-in-app/src/ffi/android.rs
+++ b/wgpu-in-app/src/ffi/android.rs
@@ -6,7 +6,8 @@ use jni::sys::{jint, jlong, jobject};
 use jni_fn::jni_fn;
 use log::info;
 
-#[no_mangle]
+// Starting with the 2024 Edition, it is now required to mark these attributes as unsafe. 
+#[unsafe(no_mangle)]
 #[jni_fn("name.jinleili.wgpu.RustBridge")]
 pub fn createWgpuCanvas(env: *mut JNIEnv, _: JClass, surface: jobject, idx: jint) -> jlong {
     crate::init_logger();
@@ -17,14 +18,14 @@ pub fn createWgpuCanvas(env: *mut JNIEnv, _: JClass, surface: jobject, idx: jint
     Box::into_raw(Box::new(canvas)) as jlong
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[jni_fn("name.jinleili.wgpu.RustBridge")]
 pub fn enterFrame(_env: *mut JNIEnv, _: JClass, obj: jlong) {
     let obj = unsafe { &mut *(obj as *mut WgpuCanvas) };
     obj.enter_frame();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[jni_fn("name.jinleili.wgpu.RustBridge")]
 pub fn changeExample(_env: *mut JNIEnv, _: JClass, obj: jlong, idx: jint) {
     // 获取到指针指代的 Rust 对象的可变借用
@@ -32,7 +33,7 @@ pub fn changeExample(_env: *mut JNIEnv, _: JClass, obj: jlong, idx: jint) {
     obj.change_example(idx);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[jni_fn("name.jinleili.wgpu.RustBridge")]
 pub fn dropWgpuCanvas(_env: *mut JNIEnv, _: JClass, obj: jlong) {
     let _obj: Box<WgpuCanvas> = unsafe { Box::from_raw(obj as *mut _) };


### PR DESCRIPTION
Starting with the 2024 Edition, it is now required to mark these attributes as unsafe. [rust-2024 unsafe-attributes](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-attributes.html)